### PR TITLE
Add "RainbowTabsFork" suffix to the addon name

### DIFF
--- a/webextensions/_locales/de/messages.json
+++ b/webextensions/_locales/de/messages.json
@@ -1,5 +1,5 @@
 {
-  "extensionName": { "message": "Tree Style Tab" },
+  "extensionName": { "message": "Tree Style Tab RainbowTabsFork" },
   "extensionDescription": { "message": "Stellt Tabs in einer Baumstruktur dar." },
 
   "sidebarTitle": { "message": "Tree Style Tab" },

--- a/webextensions/_locales/en/messages.json
+++ b/webextensions/_locales/en/messages.json
@@ -1,5 +1,5 @@
 {
-  "extensionName": { "message": "Tree Style Tab" },
+  "extensionName": { "message": "Tree Style Tab RainbowTabsFork" },
   "extensionDescription": { "message": "Show tabs like a tree." },
 
   "sidebarTitle": { "message": "Tree Style Tab" },

--- a/webextensions/_locales/ja/messages.json
+++ b/webextensions/_locales/ja/messages.json
@@ -1,5 +1,5 @@
 {
-  "extensionName": { "message": "ツリー型タブ" },
+  "extensionName": { "message": "ツリー型タブ RainbowTabsFork" },
   "extensionDescription": { "message": "タブをツリー状に表示します。" },
 
   "sidebarTitle": { "message": "ツリー型タブ" },

--- a/webextensions/_locales/zh_CN/messages.json
+++ b/webextensions/_locales/zh_CN/messages.json
@@ -1,5 +1,5 @@
 {
-  "extensionName": { "message": "Tree Style Tab" },
+  "extensionName": { "message": "Tree Style Tab RainbowTabsFork" },
   "extensionDescription": { "message": "树状显示标签页。" },
 
   "sidebarTitle": { "message": "Tree Style Tab" },

--- a/webextensions/_locales/zh_TW/messages.json
+++ b/webextensions/_locales/zh_TW/messages.json
@@ -1,5 +1,5 @@
 {
-  "extensionName": { "message": "Tree Style Tab" },
+  "extensionName": { "message": "Tree Style Tab RainbowTabsFork" },
   "extensionDescription": { "message": "以樹狀結構表示分頁" },
 
   "sidebarTitle": { "message": "Tree Style Tab" },


### PR DESCRIPTION
I've realized that [your forked version](https://addons.mozilla.org/en-US/firefox/addon/tree-style-tab-rainbowtabsfork/) is named as "Tree Style Tab RainbowTabsFork" in English, and there is no such suffix in [its Japanese page](https://addons.mozilla.org/ja/firefox/addon/tree-style-tab-rainbowtabsfork/). For better distinguishability, could you add the suffix for other language pages on AMO also? (So this pull request may unnecessary and I'm happy even if you just update registered information on AMO.)